### PR TITLE
HDF-2299 test: transport module without link

### DIFF
--- a/src/components/TransportModule/TransportModule.jsx
+++ b/src/components/TransportModule/TransportModule.jsx
@@ -97,7 +97,7 @@ export const TransportModule = ({
               ) => {
                 return (
                   <div
-                    className={`c-box ${layoutStyle[cols]} ${
+                    className={`c-box ${href ? '' : 'c-box--no-link'} ${layoutStyle[cols]} ${
                       cols === "1" ? alignStyle[alignBoxes] : ""
                     }`}
                   >

--- a/src/css/components/c-transport-module.scss
+++ b/src/css/components/c-transport-module.scss
@@ -73,7 +73,11 @@
       -webkit-line-clamp: initial;
       line-clamp: initial;
 
+      & p:first-child {
+        margin-block-start: 0;
+      }
       & p {
+        margin-block-start: 1rem;
         max-height: initial;
         -webkit-line-clamp: initial;
         line-clamp: initial;

--- a/src/css/components/c-transport-module.scss
+++ b/src/css/components/c-transport-module.scss
@@ -66,4 +66,18 @@
     box-orient: vertical;
     text-overflow: ellipsis;
   }
+
+  &--no-link & {
+    &__text-body {
+      max-height: initial;
+      -webkit-line-clamp: initial;
+      line-clamp: initial;
+
+      & p {
+        max-height: initial;
+        -webkit-line-clamp: initial;
+        line-clamp: initial;
+      }
+    }
+  }
 }


### PR DESCRIPTION
Remove max height and line clamp of transport module without link.
Added space between paragraphs in body text.